### PR TITLE
Hotfix Navigation Bar fix for v0.1

### DIFF
--- a/components/Navigation/Context.tsx
+++ b/components/Navigation/Context.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react'
+import React, { useContext, useRef, useState } from 'react'
 
 const MenuContext = React.createContext({})
 
@@ -10,12 +10,31 @@ export function MenuProvider({children}) {
 
     const [show, setShow] = useState(false)
     const [info, setInfo] = useState("Test")
+    const [display, setDisplay] = useState(false)
+    const timer = useRef(null)
+
+    const menuItemHoverEnd = () => {        
+        timer.current = setTimeout(() => {
+            setShow(false) 
+        }, 600);
+    }
+
+    const menuItemHoverStart = (data) => {
+        setShow(true)
+        clearTimeout(timer.current)
+        setInfo(data)
+    }
 
     const value = {
         show,
         setShow,
         info,
         setInfo,
+        display, 
+        timer, 
+        setDisplay,
+        menuItemHoverEnd,
+        menuItemHoverStart
     }
 
     return (

--- a/components/Navigation/MegaMenu.tsx
+++ b/components/Navigation/MegaMenu.tsx
@@ -6,11 +6,12 @@ import {motion} from 'framer-motion'
 function MegaMenu() {
 
     const {show, info}:any = useMenu();
+    const [hide, setHide] = useState(true)
 
     useEffect(() => {
         if(show){
             setDisplay(true)
-
+            setHide(false)
             setTimeout(() => {
                 setDisplay(false)
             }, 600);
@@ -57,12 +58,15 @@ function MegaMenu() {
                 setTimeout(() => {
                     setDisplay(false)
                 }, 400);
-            }} 
+            }}
+            onAnimationComplete={definition => {
+                if(definition === "closed") setHide(true)
+            }}
             variants={variants_display}
             initial={variants_display.closed}
             custom={findSize()}
             animate={findVariant()}
-            className="w-full mt-14 absolute left-0"
+            className={"w-full mt-14 absolute left-0 " + (hide ? 'hidden' : '')}
         >
             <motion.div
                 animate={{

--- a/components/Navigation/MegaMenu.tsx
+++ b/components/Navigation/MegaMenu.tsx
@@ -1,25 +1,20 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useMenu } from './Context'
 import {motion} from 'framer-motion'
 
-
 function MegaMenu() {
 
-    const {show, info}:any = useMenu();
+    const {show, info, display, setDisplay, setShow, timer}:any = useMenu();
     const [hide, setHide] = useState(true)
+    const timeout = useRef(null)
+    const timeout_animate = useRef(null)
 
     useEffect(() => {
         if(show){
             setDisplay(true)
             setHide(false)
-            setTimeout(() => {
-                setDisplay(false)
-            }, 600);
-
         }
-    }, [show])
-
-    const [display, setDisplay] = useState(false)
+    }, [setDisplay, show])
 
     const findVariant = () => {
         if(show || display){
@@ -53,14 +48,25 @@ function MegaMenu() {
 
     return (
         <motion.div 
-            onHoverStart={()=>{setDisplay(true)}} 
+            onHoverStart={()=>{
+                setDisplay(true)
+                clearTimeout(timeout.current)
+                clearTimeout(timeout_animate.current)
+            }} 
             onHoverEnd={()=>{
-                setTimeout(() => {
+                timeout.current = setTimeout(() => {
                     setDisplay(false)
-                }, 400);
+                }, 800);
             }}
             onAnimationComplete={definition => {
-                if(definition === "closed") setHide(true)
+                if(definition === "closed") {
+                    setHide(true)
+                    setDisplay(false)
+                } else {
+                    timeout_animate.current = setTimeout(() => {
+                        setDisplay(false)
+                    } , 800);
+                }
             }}
             variants={variants_display}
             initial={variants_display.closed}

--- a/components/Navigation/MegaMenuItem.tsx
+++ b/components/Navigation/MegaMenuItem.tsx
@@ -1,26 +1,14 @@
 import { useMenu } from "./Context";
 import {motion} from 'framer-motion'
 
-let timeout;
-
 function MegaMenuItem({name,data}){
 
-    const {setShow, setInfo, show}:any = useMenu();
-
+    let {menuItemHoverStart, menuItemHoverEnd}:any = useMenu();
+    
     return (
         <motion.div 
-            onHoverStart={()=>{
-                if(show) {
-                    clearTimeout(timeout)
-                }
-                setShow(true)
-                setInfo(data)
-            }}
-            onHoverEnd={()=>{
-                timeout = setTimeout(() => {
-                    setShow(false)
-                }, 400);
-            }}
+            onHoverStart={()=>{menuItemHoverStart(data)}}
+            onHoverEnd={menuItemHoverEnd}
         >
             <motion.span
                 

--- a/components/Navigation/index.tsx
+++ b/components/Navigation/index.tsx
@@ -15,16 +15,6 @@ function Navigation() {
     const [moved, setMoved] = React.useState(false);
     const [open, setOpen] = React.useState(false);
 
-    function update() {
-        //@ts-ignore
-        if (scrollY?.current < scrollY?.prev) {
-            setMoved(false);
-        //@ts-ignore
-        } else if (scrollY?.current > 30 && scrollY?.current > scrollY?.prev) {
-            setMoved(true);
-        }
-    }
-
     /** update the onChange callback to call for `update()` **/
     React.useEffect(() => {
         
@@ -33,8 +23,16 @@ function Navigation() {
             setMoved(true);
         }
 
-        return scrollY.onChange(() => update());
-    });
+        return scrollY.onChange(() => {
+            //@ts-ignore
+            if (scrollY?.current < scrollY?.prev) {
+                setMoved(false);
+            //@ts-ignore
+            } else if (scrollY?.current > 30 && scrollY?.current > scrollY?.prev) {
+                setMoved(true);
+            }
+        });
+    }, [scrollY]);
 
     const variants = {
         /** this is the "top" key and it's correlating styles **/
@@ -68,7 +66,7 @@ function Navigation() {
                         }}
 
                     >
-                        <img width={55} src="/logo.svg" />
+                        <img width={55} alt="NNDYM Logo" src="/logo.svg" />
                         <MenuProvider>
                             <nav className='hidden md:flex'>
                                 {menu_items_top.map((item, index) => item.big ? (


### PR DESCRIPTION
An issue where the navigation bar would hide when the user interacts with it too quickly has now been fixed

cause of the issue: setTimeout would reset the ref on rerendering causing react to lose track of time hence being unable to remove it, created a react ref instead, the problem seems to be fixed now!